### PR TITLE
Fix typo in `lessons/01-intro-to-genai/solution/solution-quiz`

### DIFF
--- a/lessons/01-intro-to-genai/solution/solution-quiz.md
+++ b/lessons/01-intro-to-genai/solution/solution-quiz.md
@@ -8,7 +8,7 @@ Generative AI can generate text, images, and even code.
 
 ❌ **Incorrect.**
 
-🔍 **Explanation:** While the statement is factually true, it's not incorrect in a quiz context. However, to improve clarity and precision:
+🔍 **Explanation:** While the statement is factually true, it's incorrect in a quiz context. However, to improve clarity and precision:
 
 ✅ **Better Version:**  
 Generative AI is capable of generating a variety of content such as text, images, and even code, depending on the model and its training data.


### PR DESCRIPTION
The original sentence reads:

> While the statement is factually true, it's not incorrect in a quiz context.

It should be either `not correct` or `incorrect`, not `not incorrect`. 

I updated it to `incorrect`.